### PR TITLE
Remove PyPy from default Travis environments.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py33, py34, py35
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
A Travis build on PyPy for an unmodified cookiecutter-pypackage install will
fail because it can't install the cryptography dependency. Cryptography will
support the next release of PyPy but for the time being cookiecutter-pypackage
can't be used on PyPy.
